### PR TITLE
为了兼容4字节unicode字符，chars.split改为Array.from(chars)

### DIFF
--- a/src/spider/concat.js
+++ b/src/spider/concat.js
@@ -34,7 +34,7 @@ function concat(webFonts, adapter) {
 
     newWebFonts.forEach(function(webFont) {
 
-        var chars = webFont.chars.split('');
+        var chars = Array.from(webFont.chars);
 
         // 对字符进行除重操作
         if (adapter.unique) {


### PR DESCRIPTION
chars.split('') 会将4字节unicode字符拆成两个字符，改为Array.from(chars)