### PR TITLE
make sure the space is included in the glyphs

### DIFF
--- a/src/compressor/index.js
+++ b/src/compressor/index.js
@@ -138,7 +138,7 @@ Compress.prototype = {
 
         fontmin.use(Fontmin.glyph({
             trim: false,
-            text: webFont.chars || '#' // 传入任意字符避免 fontmin@0.9.5 BUG
+            text: webFont.chars + ' '
         }));
 
 


### PR DESCRIPTION
The spider did not include the space (0x20) as a char, but that is a very important glyph for typesetting.

I can see a char "#" in the code to make sure the text is not empty, so I have just changed `|| '#'` to `+ ' '` to solve the two problems simultaneously.